### PR TITLE
Add scheme support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ commands:
             . ~/workspace/<< parameters.virtual-environment-name >>/bin/activate
             mkdir -p build/reports
             mkdir -p build/circleci/nosetests
-            nosetests --with-coverage --cover-package klempner \
+            nosetests --with-coverage \
               --cover-xml --cover-xml-file build/reports/coverage.xml \
               --with-xunit --xunit-file build/reports/nosetests.xml
             cp .coverage ~/workspace/<< parameters.coverage-file >>

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.egg-info
 *.pyc
 .coverage
+.eggs/
 build/
 dist/
 env/

--- a/README.rst
+++ b/README.rst
@@ -22,11 +22,8 @@ is its ability to discover the scheme, host name, and port number based on the
 operating environment.
 
 ``build_url`` uses the ``http`` scheme by default.  If the port is determined
-by the discovery mechanism, then the scheme is set to the service name returned
-from `socket.getservbyport`_.
-
-.. _socket.getservbyport: https://docs.python.org/3/library/socket.html
-   #socket.getservbyport
+by the discovery mechanism, then the scheme is set using a simple global
+mapping from port number to scheme.
 
 Discovery examples
 ------------------
@@ -62,7 +59,7 @@ port has a registered service associated with it, then the service name will
 be used as the scheme.
 
 Assuming that the *account* service is registered in consul with a service port
-of 8000::
+of 8000:
 
 .. code-block:: python
 
@@ -70,14 +67,16 @@ of 8000::
    url = klempner.url.build_url('account')
    print(url)  # http://account.service.production.consul:8000/
 
-Now let's look at what happens for a RabbitMQ connection::
+Now let's look at what happens for a RabbitMQ connection:
 
 .. code-block:: python
 
    url = klempner.url.build_url('rabbit')
    print(url)  # amqp://rabbit.service.production.consul:5432/
 
-The scheme is derived by calling ``socket.getservbyport(5432)``
+The scheme is derived by looking up the port in the
+``klempner.config.URL_SCHEME_MAP`` and using the result if the lookup
+succeeds.
 
 The library will connect to the agent specified by the ``CONSUL_HTTP_ADDR``
 environment variable.  If the environment variable is not specified, then the

--- a/README.rst
+++ b/README.rst
@@ -117,7 +117,7 @@ selects the service using the "com.docker.compose.service" label.
 Environment variable discovery
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This form of discovery uses environment variables with the service name encoded
-into them::
+into them:
 
 .. code-block:: python
 
@@ -129,18 +129,19 @@ into them::
 For a service named ``adder``, the following table lists the environment
 variables that are applicable:
 
-+------------------+-------------------------------+-----------+
-| Name             | URL component                 | Default   |
-+------------------+-------------------------------+-----------+
-| ``ADDER_HOST``   | host portion of the authority | *none*    |
-+------------------+-------------------------------+-----------+
-| ``ADDER_PORT``   | port portion of the authority | *omitted* |
-+------------------+-------------------------------+-----------+
-| ``ADDER_SCHEME`` | scheme                        | ``http``  |
-+------------------+-------------------------------+-----------+
++------------------+-------------------------------+-------------+
+| Name             | URL component                 | Default     |
++------------------+-------------------------------+-------------+
+| ``ADDER_HOST``   | host portion of the authority | *none*      |
++------------------+-------------------------------+-------------+
+| ``ADDER_PORT``   | port portion of the authority | *omitted*   |
++------------------+-------------------------------+-------------+
+| ``ADDER_SCHEME`` | scheme                        | *see below* |
++------------------+-------------------------------+-------------+
 
-The URL scheme will be set using `socket.getservbyport`_ if the port is set
-and the scheme is not::
+The URL scheme defaults to looking up the port number in the
+``klempner.config.URL_SCHEME_MAP`` dictionary.  If the port number is not
+in the dictionary, then ``http`` is used as a default.
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,8 @@ selects the service using the "com.docker.compose.service" label.
 
 Environment variable discovery
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This form of discovery uses environment variables with the service name encoded
+into them::
 
 .. code-block:: python
 
@@ -123,3 +125,27 @@ Environment variable discovery
    os.environ['ACCOUNT_PORT'] = '11223'
    url = klempner.url.build_url('account')
    print(url)  # http://10.2.12.23:11223/
+
+For a service named ``adder``, the following table lists the environment
+variables that are applicable:
+
++------------------+-------------------------------+-----------+
+| Name             | URL component                 | Default   |
++------------------+-------------------------------+-----------+
+| ``ADDER_HOST``   | host portion of the authority | *none*    |
++------------------+-------------------------------+-----------+
+| ``ADDER_PORT``   | port portion of the authority | *omitted* |
++------------------+-------------------------------+-----------+
+| ``ADDER_SCHEME`` | scheme                        | ``http``  |
++------------------+-------------------------------+-----------+
+
+The URL scheme will be set using `socket.getservbyport`_ if the port is set
+and the scheme is not::
+
+.. code-block:: python
+
+   os.environ['ACCOUNT_HOST'] = '10.2.12.23'
+   os.environ['ACCOUNT_PORT'] = '443'
+   url = klempner.url.build_url('account')
+   print(url)  # https://10.2.12.23:443/
+

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,19 @@ URL building
    print(url)
    # http://account/path/with%20spaces?query=arg&multi=arg&multi=support
 
+``build_url`` takes care of formatting the path and query parameters correctly
+in addition to discovering the service name.  In this example, the service name
+is used as-is (see *Unconfigured usage* below).  The real power in ``build_url``
+is its ability to discover the scheme, host name, and port number based on the
+operating environment.
+
+``build_url`` uses the ``http`` scheme by default.  If the port is determined
+by the discovery mechanism, then the scheme is set to the service name returned
+from `socket.getservbyport`_.
+
+.. _socket.getservbyport: https://docs.python.org/3/library/socket.html
+   #socket.getservbyport
+
 Discovery examples
 ------------------
 
@@ -44,7 +57,12 @@ interface exposes.
    print(url)  # http://account.service.production.consul/
 
 If you append ``+agent`` to the discovery method, then ``build_url`` will
-connect to a Consul agent and retrieve the port number for services.
+connect to a Consul agent and retrieve the port number for services.  If the
+port has a registered service associated with it, then the service name will
+be used as the scheme.
+
+Assuming that the *account* service is registered in consul with a service port
+of 8000::
 
 .. code-block:: python
 
@@ -52,9 +70,18 @@ connect to a Consul agent and retrieve the port number for services.
    url = klempner.url.build_url('account')
    print(url)  # http://account.service.production.consul:8000/
 
-The Consul agent will connect to the agent specified by the
-``CONSUL_HTTP_ADDR`` environment variable.  If the environment variable is
-not specified, then the agent on the localhost will be used.
+Now let's look at what happens for a RabbitMQ connection::
+
+.. code-block:: python
+
+   url = klempner.url.build_url('rabbit')
+   print(url)  # amqp://rabbit.service.production.consul:5432/
+
+The scheme is derived by calling ``socket.getservbyport(5432)``
+
+The library will connect to the agent specified by the ``CONSUL_HTTP_ADDR``
+environment variable.  If the environment variable is not specified, then the
+agent listening on the localhost will be used.
 
 Kubernetes service discovery
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -121,13 +121,14 @@ into them:
 
 .. code-block:: python
 
+   os.environ['KLEMPNER_DISCOVERY'] = 'environment'
    os.environ['ACCOUNT_HOST'] = '10.2.12.23'
    os.environ['ACCOUNT_PORT'] = '11223'
    url = klempner.url.build_url('account')
    print(url)  # http://10.2.12.23:11223/
 
-For a service named ``adder``, the following table lists the environment
-variables that are applicable:
+For a service named ``adder``, the following environment variables are used
+if they are set.
 
 +------------------+-------------------------------+-------------+
 | Name             | URL component                 | Default     |
@@ -145,6 +146,7 @@ in the dictionary, then ``http`` is used as a default.
 
 .. code-block:: python
 
+   os.environ['KLEMPNER_DISCOVERY'] = 'environment'
    os.environ['ACCOUNT_HOST'] = '10.2.12.23'
    os.environ['ACCOUNT_PORT'] = '443'
    url = klempner.url.build_url('account')

--- a/ci/git-pre-commit
+++ b/ci/git-pre-commit
@@ -39,7 +39,7 @@ then
 	cat|$fmt -w $columns<<-EOF
 		You have unstaged changes to some files in your
 		commit; skipping auto-format. Please stage, stash,
-		or revert these changes. You may find `git stash -k`
+		or revert these changes. You may find "git stash -k"
 		helpful here.
 
 		Files with unstaged changes: $changed_files

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -61,6 +61,45 @@ from a consul agent instead of an environment variable.
 The consul agent endpoint is configured by the :envvar:`CONSUL_HTTP_ADDR`
 environment variable.
 
+.. _environment-discovery-method:
+
+environment
+~~~~~~~~~~~
+The *environment* discovery method uses environment variables to configure
+service endpoints.  When :func:`~klempner.url.build_url` is called for a
+service, several environment variables will be used to build the URL if they
+are defined.  The service name is upper-cased and each of the following
+suffixes are appended to calculate the URL compoment.
+
++-------------+-------------------------------+---------------------+
+| Suffix      | URL component                 | Default             |
++-------------+-------------------------------+---------------------+
+| ``_HOST``   | host portion of the authority | name of the service |
++-------------+-------------------------------+---------------------+
+| ``_PORT``   | port portion of the authority | *omitted*           |
++-------------+-------------------------------+---------------------+
+| ``_SCHEME`` | scheme                        | *see below*         |
++-------------+-------------------------------+---------------------+
+
+The URL scheme defaults to looking up the port number in the
+``klempner.config.URL_SCHEME_MAP`` dictionary.  If the port number is not
+in the dictionary, then ``http`` is used as a default.
+
+.. rubric:: Special case for docker/kubernetes linking
+
+If you are still using version 1 docker-compose files or you are deploying
+in a Kubernetes cluster, then the ``..._PORT`` environment variable is set
+something very much not a port number.  For example, if there is a service
+named ``foo`` is available on the host ``1.2.3.4`` and port ``5678``, then
+``$FOO_PORT`` is set to ``tcp://1.2.3.4:5678``.  Needless to say that this
+is not a simple port number and should not be treated as such.  See the
+`kubernetes service discovery`_ documentation for more detail.  If the port
+environment variable matches this pattern, then the host and port are parsed
+from the URL.
+
+.. _kubernetes service discovery: https://kubernetes.io/docs/concepts
+   /services-networking/service/#environment-variables
+
 .. _kubernetes-discovery-method:
 
 kubernetes
@@ -88,10 +127,11 @@ The library can be configured based on the environment by calling the
    Controls the discovery method that the library will used.  The following
    values are understood:
 
-      - :ref:`simple-discovery-method`
       - :ref:`consul-discovery-method`
       - :ref:`consul-agent-discovery-method`
+      - :ref:`environment-discovery-method`
       - :ref:`kubernetes-discovery-method`
+      - :ref:`simple-discovery-method`
 
 .. envvar:: CONSUL_DATACENTER
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -32,6 +32,7 @@ The *simple* discovery method simply inserts the service name into the
 the port is left as the protocol default (unspecified).
 
 .. productionlist::
+   scheme    : "http"
    host      : service-name
 
 .. _consul-discovery-method:
@@ -42,6 +43,7 @@ The *consul* discovery method combines the service name and the consul data
 center to build the DNS CNAME that consul advertises:
 
 .. productionlist::
+   scheme    : "http"
    host      : service-name ".service." data-center ".consul"
 
 The data center name is configured by the :envvar:`CONSUL_DATACENTER`
@@ -51,15 +53,24 @@ environment variable.
 
 consul+agent
 ~~~~~~~~~~~~
-The *consul-agent* discovery method is similar to the
-:ref:`consul-discovery-method` method except that the data-center is discovered
-from a consul agent instead of an environment variable.
+The *consul-agent* discovery method retrieves the service information from
+a consul agent by `listing the available nodes`_ from the agent.  The
+service record includes the host name, port number, and configured metadata.
 
-.. productionlist::
-   host      : service-name ".service." data-center ".consul"
+Instead of selecting a host name from the available nodes, the advertised
+DNS name is used (see `consul-discovery-method`_ section) as the *host portion*.
+
+The *port number* from the first advertised node is used.
+
+If the protocol is included in the service metadata, then it is used as the
+*scheme* for the URL.  Otherwise, the port number is mapped through the
+:data:`~klempner.config.URL_SCHEME_MAP` to determine the scheme to apply.
 
 The consul agent endpoint is configured by the :envvar:`CONSUL_HTTP_ADDR`
 environment variable.
+
+.. _listing the available nodes: https://www.consul.io/api/catalog.html
+   #list-nodes-for-service
 
 .. _environment-discovery-method:
 
@@ -111,7 +122,7 @@ CNAMEs that `Kubernetes advertises`_.
 .. productionlist::
    host      : service-name "." namespace ".svc.cluster.local"
 
-The namespace is configured by the :envvar:`KUBERNETES_NAMESPACE` environemnt
+The namespace is configured by the :envvar:`KUBERNETES_NAMESPACE` environment
 variable.
 
 .. _Kubernetes advertises: https://kubernetes.io/docs/concepts

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -109,3 +109,37 @@ The library can be configured based on the environment by calling the
    Configures the name of the Kubernetes namespace used by
    :ref:`kubernetes-discovery-method` to generate URLs.  If this variable is
    not set, the value of ``default`` is used.
+
+URL schemes
+-----------
+The default scheme for all URLs is ``http``.  If a port number is available
+for the configured discovery scheme, then the port number is looked up in
+:data:`klempner.config.URL_SCHEME_MAP` and the result is used as the URL
+scheme.  The initial content of the mapping contains many of the `IANA
+registered schemes`_ as well as a number of other commonly used ones (e.g.,
+``postgresql``, ``amqp``).
+
+You can adjust the *port to scheme* mapping to match your needs.  If you
+want to disable scheme mapping altogether, simply clear the mapping when
+your application initializes:
+
+.. code-block:: python
+
+   klempner.config.URL_SCHEME_MAP.clear()
+
+Use the ``update`` operation if you need to augment the mapping or override
+specific entries:
+
+.. code-block:: python
+
+   klempner.config.URL_SCHEME_MAP.update({
+      5672: 'rabbitmq',
+      15672: 'rabbitmq-admin',
+   })
+
+The mapping is a simple :class:`dict` so you can manipulate it using the
+standard methods.  It is not cached anywhere in the library implementation
+so all modifications are immediately reflected in API calls.
+
+.. _IANA registered schemes: https://www.iana.org/assignments/uri-schemes
+   /uri-schemes.xhtml

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -3,3 +3,6 @@ div.document {width: 90%}
 div.body {max-width: initial;}
 div.code-block-caption {padding-bottom: 10px}
 span.caption-text {font-size: large; font-weight: bold; font-family: Georgia, serif}
+
+/* hide "ugly" data values */
+#klempner\.config\.URL_SCHEME_MAP em.property {display: none}

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,11 @@
 Release history
 ===============
 
+`Next Release`_
+---------------
+- Add :data:`~klempner.config.URL_SCHEME_MAP` so that URL schemes can be
+  easily configured.
+
 `0.0.1`_ (5 May 2019)
 ---------------------
 - Implement :ref:`simple-discovery-method`, :ref:`consul-discovery-method`,

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,6 +5,9 @@ Release history
 ---------------
 - Add :data:`~klempner.config.URL_SCHEME_MAP` so that URL schemes can be
   easily configured.
+- Separate the :ref:`environment-discovery-method` method out from the
+  :ref:`simple-discovery-method` method.  Previously the simple method would
+  fall back to using environment variables if they were set.
 
 `0.0.1`_ (5 May 2019)
 ---------------------

--- a/klempner/config.py
+++ b/klempner/config.py
@@ -5,6 +5,44 @@ import requests
 
 from klempner import compat, errors
 
+URL_SCHEME_MAP = {
+    5672: 'amqp',  # https://www.rabbitmq.com/uri-spec.html
+    21: 'ftp',  # https://tools.ietf.org/html/rfc1738
+    70: 'gopher',  # https://tools.ietf.org/html/rfc4266
+    80: 'http',  # https://tools.ietf.org/html/rfc7230#section-2.7.1
+    443: 'https',  # https://tools.ietf.org/html/rfc7230#section-2.7.2
+    1344: 'icap',  # https://tools.ietf.org/html/rfc3507#section-4.2
+    631: 'ipp',  # https://tools.ietf.org/html/rfc3510
+    389: 'ldap',  # https://tools.ietf.org/html/rfc4516
+    636: 'ldaps',  # https://tools.ietf.org/html/rfc4516
+    # https://docs.mongodb.com/manual/reference/connection-string/
+    27017: 'mongodb',
+    3306: 'mysql',
+    119: 'nntp',  # https://tools.ietf.org/html/rfc5538
+    110: 'pop',  # https://tools.ietf.org/html/rfc2384
+    # https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+    5432: 'postgresql',
+    6379: 'redis',  # https://www.iana.org/assignments/uri-schemes/prov/redis
+    873: 'rsync',  # https://tools.ietf.org/html/rfc5781
+    554: 'rtsp',  # https://tools.ietf.org/html/rfc7826#section-4.2
+    322: 'rtsps',  # https://tools.ietf.org/html/rfc7826#section-4.2
+    25: 'smtp',  # https://tools.ietf.org/html/draft-melnikov-smime-msa-to-mda
+    161: 'snmp',  # https://tools.ietf.org/html/rfc4088
+    22: 'ssh',  # https://tools.ietf.org/html/draft-ietf-secsh-scp-sftp-ssh-uri
+    23: 'telnet',  # https://tools.ietf.org/html/rfc4248
+    69: 'tftp',  # https://tools.ietf.org/html/rfc3617
+    3372: 'tip',  # https://tools.ietf.org/html/rfc2371
+    5900: 'vnc',  # https://tools.ietf.org/html/rfc7869
+    602: 'xmlrpc.beep',  # https://tools.ietf.org/html/rfc3529#section-5.1
+}
+"""Mapping of port number to URL scheme.
+
+This dictionary is used to identify the URL scheme based on the port number
+when a port number is available.  Users of the library MAY modify the content
+of this dictionary **at any time**.
+
+"""
+
 
 class DiscoveryMethod(object):
     """Available discovery methods."""

--- a/klempner/config.py
+++ b/klempner/config.py
@@ -56,6 +56,9 @@ class DiscoveryMethod(object):
     CONSUL_AGENT = 'consul+agent'
     """Build consul-based service URLs using a consul agent."""
 
+    ENV_VARS = 'environment'
+    """Build URLs based on _HOST, _PORT, and _SCHEME environment variables."""
+
     K8S = 'kubernetes'
     """Build Kubernetes cluster-based service URLs."""
 
@@ -63,7 +66,7 @@ class DiscoveryMethod(object):
 
     UNSET = object()
 
-    AVAILABLE = (CONSUL, CONSUL_AGENT, K8S, SIMPLE, UNSET)
+    AVAILABLE = (CONSUL, CONSUL_AGENT, ENV_VARS, K8S, SIMPLE, UNSET)
 
 
 _discovery_method = DiscoveryMethod.UNSET

--- a/klempner/url.py
+++ b/klempner/url.py
@@ -26,7 +26,8 @@ class ConsulAgentAdapter(requests.adapters.HTTPAdapter):
 
     def send(self, request, stream=False, timeout=None, verify=True, cert=None,
              proxies=None):
-        _, _, path, params, query, fragment = compat.urlparse(request.url)
+        _, host, path, params, query, fragment = compat.urlparse(request.url)
+        path = host + path
         request.url = compat.urlunparse(
             ('http', os.environ['CONSUL_HTTP_ADDR'], path, params, query,
              fragment))
@@ -130,7 +131,7 @@ def _write_network_portion(buf, service):
         body = _state.discovery_cache.get(service, sentinel)
         if body is sentinel:
             response = _state.session.get(
-                'consul://agent/v1/catalog/service/{0}'.format(service))
+                'consul://v1/catalog/service/{0}'.format(service))
             response.raise_for_status()
             body = response.json()
             _state.discovery_cache[service] = body

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,13 @@ exclude =
 	dist
 	env
 
+[nosetests]
+cover-branches = yes
+cover-erase = yes
+cover-html = yes
+cover-html-dir = build/coverage
+cover-package = klempner
+
 [yapf]
 split_complex_comprehension = yes
 split_before_first_argument = no

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -104,7 +104,7 @@ class SchemeMappingTests(tests.helpers.EnvironmentMixin, unittest.TestCase):
 
     def test_that_mapping_can_be_disabled(self):
         config.URL_SCHEME_MAP.clear()
-        config.configure(config.DiscoveryMethod.SIMPLE)
+        config.configure(config.DiscoveryMethod.ENV_VARS)
         self.setenv('ACCOUNT_HOST', 'account.example.com')
         self.setenv('ACCOUNT_PORT', '443')
         self.assertEqual('http://account.example.com:443/',
@@ -112,7 +112,7 @@ class SchemeMappingTests(tests.helpers.EnvironmentMixin, unittest.TestCase):
 
     def test_that_mapping_can_be_overridden(self):
         config.URL_SCHEME_MAP[5672] = 'rabbitmq'
-        config.configure(config.DiscoveryMethod.SIMPLE)
+        config.configure(config.DiscoveryMethod.ENV_VARS)
         self.setenv('ACCOUNT_HOST', 'account.example.com')
         self.setenv('ACCOUNT_PORT', '5672')
         self.assertEqual('rabbitmq://account.example.com:5672/',

--- a/tests/test_consul_discovery.py
+++ b/tests/test_consul_discovery.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import os
 import random
-import socket
 import unittest
 import uuid
 
@@ -110,17 +109,9 @@ class AgentBasedTests(helpers.EnvironmentMixin, unittest.TestCase):
                          klempner.url.build_url(service_info['Name']))
 
     def test_that_scheme_set_by_port(self):
-        for expected_scheme in ('amqp', 'postgresql', 'https', 'rtsp', 'sip'):
-            try:
-                port = socket.getservbyname(expected_scheme)
-                break
-            except OSError:
-                pass
-        else:
-            raise unittest.SkipTest('known schemas are not supported')
-
-        service_info = self.register_service(port=port)
-        name, datacenter = service_info['Name'], service_info['Datacenter']
-        self.assertEqual(
-            f'{expected_scheme}://{name}.service.{datacenter}.consul:{port}/',
-            klempner.url.build_url(name))
+        for port, scheme in klempner.config.URL_SCHEME_MAP.items():
+            service_info = self.register_service(port=port)
+            self.assertEqual(
+                '{scheme}://{Name}.service.{Datacenter}.consul:{port}/'.format(
+                    port=port, scheme=scheme, **service_info),
+                klempner.url.build_url(service_info['Name']))

--- a/tests/test_env_discovery.py
+++ b/tests/test_env_discovery.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import unittest
 
 from tests import helpers
+import klempner.config
 import klempner.url
 
 
@@ -10,6 +11,8 @@ class SimpleEnvironmentTests(helpers.EnvironmentMixin, unittest.TestCase):
     def setUp(self):
         super(SimpleEnvironmentTests, self).setUp()
         klempner.url.reset_cache()
+        self.setenv('KLEMPNER_DISCOVERY',
+                    klempner.config.DiscoveryMethod.ENV_VARS)
 
     def test_that_scheme_envvar_is_honored(self):
         self.setenv('ACCOUNT_SCHEME', 'https')
@@ -22,31 +25,28 @@ class SimpleEnvironmentTests(helpers.EnvironmentMixin, unittest.TestCase):
         self.assertEqual('http://10.2.12.23/', url)
 
     def test_that_port_envvar_is_honored(self):
-        self.setenv('ACCOUNT_HOST', '10.2.12.23')
         self.setenv('ACCOUNT_PORT', '11223')
+        url = klempner.url.build_url('account')
+        self.assertEqual('http://account:11223/', url)
+
+    def test_that_docker_linked_port_is_accepted(self):
+        self.setenv('ACCOUNT_PORT', 'tcp://10.2.12.23:11223')
         url = klempner.url.build_url('account')
         self.assertEqual('http://10.2.12.23:11223/', url)
 
-    def test_that_port_envvar_is_ignored_unless_host_is_set(self):
-        self.unsetenv('ACCOUNT_HOST')
-        self.setenv('ACCOUNT_PORT', '11223')
-        url = klempner.url.build_url('account')
-        self.assertEqual('http://account/', url)
-
-    def test_that_docker_formatted_port_is_accepted(self):
+    def test_that_host_is_taken_from_docker_linked_port(self):
         self.setenv('ACCOUNT_HOST', '10.2.12.23')
-        self.setenv('ACCOUNT_PORT', '10.2.12.23:11223')
+        self.setenv('ACCOUNT_PORT', 'tcp://10.2.12.24:11223')
         url = klempner.url.build_url('account')
         self.assertEqual('http://10.2.12.23:11223/', url)
-
-    def test_that_host_is_taken_from_port_in_docker_formatted_port(self):
-        self.setenv('ACCOUNT_HOST', '10.2.12.23')
-        self.setenv('ACCOUNT_PORT', '10.2.12.24:11223')
-        url = klempner.url.build_url('account')
-        self.assertEqual('http://10.2.12.24:11223/', url)
 
     def test_that_scheme_is_set_from_port(self):
         self.setenv('ACCOUNT_HOST', '10.2.12.23')
         self.setenv('ACCOUNT_PORT', '443')
+        url = klempner.url.build_url('account')
+        self.assertEqual('https://10.2.12.23:443/', url)
+
+    def test_that_scheme_is_taken_from_docker_linked_port(self):
+        self.setenv('ACCOUNT_PORT', 'tcp://10.2.12.23:443')
         url = klempner.url.build_url('account')
         self.assertEqual('https://10.2.12.23:443/', url)

--- a/tests/test_env_discovery.py
+++ b/tests/test_env_discovery.py
@@ -44,3 +44,9 @@ class SimpleEnvironmentTests(helpers.EnvironmentMixin, unittest.TestCase):
         self.setenv('ACCOUNT_PORT', '10.2.12.24:11223')
         url = klempner.url.build_url('account')
         self.assertEqual('http://10.2.12.24:11223/', url)
+
+    def test_that_scheme_is_set_from_port(self):
+        self.setenv('ACCOUNT_HOST', '10.2.12.23')
+        self.setenv('ACCOUNT_PORT', '443')
+        url = klempner.url.build_url('account')
+        self.assertEqual('https://10.2.12.23:443/', url)


### PR DESCRIPTION
This PR adds support for determining the URL scheme from the port number via a configurable mapping.  I also changed the simple configuration scheme so that it really does nothing.  It was using environment variables if they were configured so I created a separate discovery scheme to do that.