### PR TITLE
Support HTTPS connections to consul agent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
   test-python-2:
     executor: python-2
     environment:
-      CONSUL_HTTP_ADDR: 127.0.0.1:8500
+      CONSUL_AGENT_URL: http://127.0.0.1:8500
     steps:
       - checkout
       - create-workspace:
@@ -134,7 +134,7 @@ jobs:
   test-python-3:
     executor: python-3
     environment:
-      CONSUL_HTTP_ADDR: 127.0.0.1:8500
+      CONSUL_AGENT_URL: http://127.0.0.1:8500
     steps:
       - checkout
       - create-workspace:

--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ The scheme is derived by looking up the port in the
 ``klempner.config.URL_SCHEME_MAP`` and using the result if the lookup
 succeeds.
 
-The library will connect to the agent specified by the ``CONSUL_HTTP_ADDR``
+The library will connect to the agent specified by the ``CONSUL_AGENT_URL``
 environment variable.  If the environment variable is not specified, then the
 agent listening on the localhost will be used.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
     working_dir: /source
     command: ./ci/docker-test
     environment:
-      CONSUL_HTTP_ADDR: consul:8500
+      CONSUL_AGENT_URL: http://consul:8500
     volumes:
       - .:/source
     depends_on:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -36,16 +36,17 @@ The library can be configured based on the environment by calling the
       - :ref:`kubernetes-discovery-method`
       - :ref:`simple-discovery-method`
 
+.. envvar:: CONSUL_AGENT_URL
+
+   Configures the Consul agent URL used by the
+   :ref:`consul-agent-discovery-method` method.  Note that the path, query,
+   and fragment portions of the URL are ignored.
+
 .. envvar:: CONSUL_DATACENTER
 
    Configures the datacenter used for Consul-based discovery methods.  This
    variable is required if :envvar:`KLEMPNER_DISCOVERY` is set to
    :ref:`consul-discovery-method`.
-
-.. envvar:: CONSUL_HTTP_ADDR
-
-   Configures the Consul agent address and port used by the
-   :ref:`consul-agent-discovery-method` method.
 
 .. envvar:: CONSUL_HTTP_TOKEN
 

--- a/docs/discovery-mechanisms.rst
+++ b/docs/discovery-mechanisms.rst
@@ -127,13 +127,13 @@ If the protocol is included in the service metadata, then it is used as the
 *scheme* for the URL.  Otherwise, the port number is mapped through the
 :data:`~klempner.config.URL_SCHEME_MAP` to determine the scheme to apply.
 
-The consul agent endpoint is configured by the :envvar:`CONSUL_HTTP_ADDR`
+The consul agent endpoint is configured by the :envvar:`CONSUL_AGENT_URL`
 environment variable.
 
 .. code-block:: python
    :caption: Consul agent lookup
 
-   os.environ['CONSUL_HTTP_ADDR'] = 'http://127.0.0.1:8500'
+   os.environ['CONSUL_AGENT_URL'] = 'http://127.0.0.1:8500'
 
    os.environ['KLEMPNER_DISCOVERY'] = 'consul+agent'
    url = klempner.url.build_url('account')

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,12 @@
 Release history
 ===============
 
+Next Release
+------------
+- :compare:`0.0.3...master`
+- Add support for using https with consul by replacing ``CONSUL_HTTP_ADDR``
+  with :envvar:`CONSUL_AGENT_URL`
+
 0.0.3 (25 May 2019)
 -------------------
 - :compare:`0.0.2...0.0.3`

--- a/klempner/config.py
+++ b/klempner/config.py
@@ -65,6 +65,12 @@ class DiscoveryMethod(object):
     DEFAULT = SIMPLE
 
     UNSET = object()
+    """The initial library state.
+
+    This can be used to reset the library internals by calling
+    :func:`.configure` with `UNSET` as the discovery method.
+
+    """
 
     AVAILABLE = (CONSUL, CONSUL_AGENT, ENV_VARS, K8S, SIMPLE, UNSET)
 
@@ -93,7 +99,15 @@ def configure(discovery_method, **parameters):
     :raises: :exc:`klempner.errors.ConfigurationError` if a required
         parameter is not provided
 
+    If `discovery_method` is :attr:`.DiscoveryMethod.UNSET`, then the
+    current configuration is cleared and the library is reset to an
+    unconfigured state.  This means that the next call to
+    :func:`~klempner.url.build_url` will configure the library based
+    on the current environment variables.
+
     """
+    from klempner import url  # late import to avoid circular dependency
+
     logger = logging.getLogger(__package__).getChild('configure')
 
     def require_parameter(name):
@@ -113,11 +127,15 @@ def configure(discovery_method, **parameters):
         incoming_parameters['datacenter'] = require_parameter('datacenter')
     elif discovery_method == DiscoveryMethod.K8S:
         incoming_parameters['namespace'] = require_parameter('namespace')
+    elif discovery_method == DiscoveryMethod.UNSET:
+        url._reset_cache()
     elif discovery_method not in DiscoveryMethod.AVAILABLE:
         raise errors.ConfigurationError('discovery_style', discovery_method)
 
     global _discovery_method, _discovery_parameters
-    if _discovery_method is DiscoveryMethod.UNSET:
+    if discovery_method is DiscoveryMethod.UNSET:
+        logger.info('resetting/clearing configuration values')
+    elif _discovery_method is DiscoveryMethod.UNSET:
         logger.info('setting discovery method to %r with parameters=%r',
                     discovery_method, incoming_parameters)
     else:

--- a/klempner/config.py
+++ b/klempner/config.py
@@ -169,8 +169,9 @@ def configure_from_environment():
                 os.environ['CONSUL_HTTP_TOKEN'])
         except KeyError:
             pass
-        url = compat.urlunparse(('http', require_envvar('CONSUL_HTTP_ADDR'),
-                                 '/v1/agent/self', None, None, None))
+        parsed = compat.urlparse(require_envvar('CONSUL_AGENT_URL'))
+        url = compat.urlunparse((parsed[0], parsed[1], '/v1/agent/self', None,
+                                 None, None))
         response = requests.get(url, headers=headers)
         response.raise_for_status()
         body = response.json()

--- a/klempner/url.py
+++ b/klempner/url.py
@@ -71,20 +71,6 @@ class State(object):
 _state = State()
 
 
-def reset_cache():
-    """Reset internal caches.
-
-    Applications MUST call this function if they have changed discovery
-    configuration details or suspect that they may have changed.  This
-    should not happen often since the discovery configuration is based
-    primarily on environment variables which are not modifiable from
-    outside of the process.
-
-    """
-    config.reset()
-    _state.clear()
-
-
 def build_url(service, *path, **query):
     """Build a URL that targets `service`.
 
@@ -119,6 +105,19 @@ def build_url(service, *path, **query):
             for name, value in query_tuples))
 
     return buf.getvalue()
+
+
+def _reset_cache():
+    """Reset internal caches.
+
+    Applications MUST call this function if they have changed discovery
+    configuration details or suspect that they may have changed.  This
+    should not happen often since the discovery configuration is based
+    primarily on environment variables which are not modifiable from
+    outside of the process.
+
+    """
+    _state.clear()
 
 
 def _write_network_portion(buf, service):

--- a/klempner/url.py
+++ b/klempner/url.py
@@ -3,9 +3,9 @@ from __future__ import unicode_literals
 import logging
 import os
 try:
-    from urllib.parse import urlsplit
+    from urllib.parse import urlsplit, urlunsplit
 except ImportError:
-    from urlparse import urlsplit
+    from urlparse import urlsplit, urlunsplit
 
 import requests.adapters
 
@@ -45,9 +45,10 @@ class State(object):
         sentinel = object()
         service_info = self.discovery_cache.get(service, sentinel)
         if service_info is sentinel:
-            url = 'http://{0}/v1/catalog/service/{1}'.format(
-                os.environ['CONSUL_HTTP_ADDR'], service)
-
+            parsed = urlsplit(os.environ['CONSUL_AGENT_URL'])
+            url = urlunsplit(
+                (parsed[0], parsed[1],
+                 '/v1/catalog/service/{0}'.format(service), '', ''))
             headers = {}
             if os.environ.get('CONSUL_HTTP_TOKEN'):
                 headers['Authorization'] = 'Bearer {0}'.format(

--- a/klempner/url.py
+++ b/klempner/url.py
@@ -2,10 +2,6 @@ from __future__ import unicode_literals
 
 import logging
 import os
-try:
-    from urllib.parse import urlsplit, urlunsplit
-except ImportError:
-    from urlparse import urlsplit, urlunsplit
 
 import requests.adapters
 
@@ -45,10 +41,10 @@ class State(object):
         sentinel = object()
         service_info = self.discovery_cache.get(service, sentinel)
         if service_info is sentinel:
-            parsed = urlsplit(os.environ['CONSUL_AGENT_URL'])
-            url = urlunsplit(
+            parsed = compat.urlparse(os.environ['CONSUL_AGENT_URL'])
+            url = compat.urlunparse(
                 (parsed[0], parsed[1],
-                 '/v1/catalog/service/{0}'.format(service), '', ''))
+                 '/v1/catalog/service/{0}'.format(service), '', '', ''))
             headers = {}
             if os.environ.get('CONSUL_HTTP_TOKEN'):
                 headers['Authorization'] = 'Bearer {0}'.format(
@@ -168,7 +164,7 @@ def _write_network_portion(buf, service):
 
         if port is not None and port.startswith('tcp://'):
             # special case for docker's ip:port format
-            parts = urlsplit(port)
+            parts = compat.urlparse(port)
             port = str(parts.port)
             if host is None:
                 host = parts.hostname

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,18 +65,18 @@ class ConfigByEnvironTests(tests.helpers.EnvironmentMixin, unittest.TestCase):
                          context.exception.configuration_name)
         self.assertIs(None, context.exception.configuration_value)
 
-    def test_that_consul_agent_discovery_without_http_addr_fails(self):
+    def test_that_consul_agent_discovery_without_agent_url_fails(self):
         self.setenv('KLEMPNER_DISCOVERY', config.DiscoveryMethod.CONSUL_AGENT)
-        self.unsetenv('CONSUL_HTTP_ADDR')
+        self.unsetenv('CONSUL_AGENT_URL')
         with self.assertRaises(errors.ConfigurationError) as context:
             config.configure_from_environment()
-        self.assertEqual('CONSUL_HTTP_ADDR',
+        self.assertEqual('CONSUL_AGENT_URL',
                          context.exception.configuration_name)
         self.assertIs(None, context.exception.configuration_value)
 
     def test_that_consul_agent_discovery_uses_consul_token(self):
         self.setenv('KLEMPNER_DISCOVERY', config.DiscoveryMethod.CONSUL_AGENT)
-        self.setenv('CONSUL_HTTP_ADDR', '127.0.0.1:1')
+        self.setenv('CONSUL_AGENT_URL', 'http://127.0.0.1:1')
         self.setenv('CONSUL_HTTP_TOKEN', 'some-token')
         with mock.patch('klempner.config.requests.get') as requests_get:
             response = mock.Mock()
@@ -91,7 +91,7 @@ class ConfigByEnvironTests(tests.helpers.EnvironmentMixin, unittest.TestCase):
         self.assertEqual('bearer some-token',
                          kwargs['headers']['Authorization'].lower())
 
-    @unittest.skipUnless('CONSUL_HTTP_ADDR' in os.environ,
+    @unittest.skipUnless('CONSUL_AGENT_URL' in os.environ,
                          'Consul agent is not present')
     def test_that_consul_agent_discovery_includes_user_agent(self):
         self.setenv('KLEMPNER_DISCOVERY', config.DiscoveryMethod.CONSUL_AGENT)

--- a/tests/test_consul_discovery.py
+++ b/tests/test_consul_discovery.py
@@ -17,7 +17,7 @@ from tests import helpers
 
 class SimpleConsulTests(helpers.EnvironmentMixin, unittest.TestCase):
     def test_that_consul_datacenter_environment_sets_datacenter_name(self):
-        klempner.url.reset_cache()
+        klempner.config.configure(klempner.config.DiscoveryMethod.UNSET)
         self.setenv('KLEMPNER_DISCOVERY',
                     klempner.config.DiscoveryMethod.CONSUL)
         env = str(uuid.uuid4())
@@ -46,7 +46,7 @@ class AgentBasedTests(helpers.EnvironmentMixin, unittest.TestCase):
 
     def setUp(self):
         super(AgentBasedTests, self).setUp()
-        klempner.url.reset_cache()
+        klempner.config.configure(klempner.config.DiscoveryMethod.UNSET)
         self.setenv('KLEMPNER_DISCOVERY',
                     klempner.config.DiscoveryMethod.CONSUL_AGENT)
         self.unsetenv('CONSUL_DATACENTER')
@@ -56,7 +56,7 @@ class AgentBasedTests(helpers.EnvironmentMixin, unittest.TestCase):
         super(AgentBasedTests, self).tearDown()
         for service_id in list(self._service_ids):
             self.deregister_service(service_id, ignore_error=True)
-        klempner.url.reset_cache()
+        klempner.config.configure(klempner.config.DiscoveryMethod.UNSET)
 
     def register_service(self, meta=None, port=None, service_name=None):
         service_id = str(uuid.uuid4())

--- a/tests/test_consul_discovery.py
+++ b/tests/test_consul_discovery.py
@@ -32,11 +32,12 @@ class AgentBasedTests(helpers.EnvironmentMixin, unittest.TestCase):
         cls.session = requests.Session()
 
         try:
-            cls.agent_url = 'http://{0}/v1/agent'.format(
-                os.environ['CONSUL_HTTP_ADDR'])
+            parsed = klempner.url.urlsplit(os.environ['CONSUL_AGENT_URL'])
         except KeyError:
             raise unittest.SkipTest('Consul agent is not present')
 
+        cls.agent_url = klempner.url.urlunsplit((parsed.scheme, parsed.netloc,
+                                                 '/v1/agent', '', ''))
         response = cls.session.get(cls.agent_url + '/self')
         response.raise_for_status()
         body = response.json()

--- a/tests/test_env_discovery.py
+++ b/tests/test_env_discovery.py
@@ -10,7 +10,7 @@ import klempner.url
 class SimpleEnvironmentTests(helpers.EnvironmentMixin, unittest.TestCase):
     def setUp(self):
         super(SimpleEnvironmentTests, self).setUp()
-        klempner.url.reset_cache()
+        klempner.config.configure(klempner.config.DiscoveryMethod.UNSET)
         self.setenv('KLEMPNER_DISCOVERY',
                     klempner.config.DiscoveryMethod.ENV_VARS)
 

--- a/tests/test_k8s_discovery.py
+++ b/tests/test_k8s_discovery.py
@@ -11,7 +11,7 @@ import klempner.url
 class SimpleK8sTests(helpers.EnvironmentMixin, unittest.TestCase):
     def setUp(self):
         super(SimpleK8sTests, self).setUp()
-        klempner.url.reset_cache()
+        klempner.config.configure(klempner.config.DiscoveryMethod.UNSET)
         self.setenv('KLEMPNER_DISCOVERY', klempner.config.DiscoveryMethod.K8S)
         self.setenv('KUBERNETES_NAMESPACE', 'development')
 

--- a/tests/test_url_building.py
+++ b/tests/test_url_building.py
@@ -2,13 +2,14 @@ from __future__ import unicode_literals
 
 import unittest
 
+import klempner.config
 import klempner.url
 
 
 class QueryParameterTests(unittest.TestCase):
     def setUp(self):
         super(QueryParameterTests, self).setUp()
-        klempner.url.reset_cache()
+        klempner.config.configure(klempner.config.DiscoveryMethod.UNSET)
 
     def test_that_query_parameters_are_encoded(self):
         url = klempner.url.build_url('some-service', arg1='value',
@@ -43,7 +44,7 @@ class QueryParameterTests(unittest.TestCase):
 class PathTests(unittest.TestCase):
     def setUp(self):
         super(PathTests, self).setUp()
-        klempner.url.reset_cache()
+        klempner.config.configure(klempner.config.DiscoveryMethod.UNSET)
 
     def test_that_path_elements_are_quoted(self):
         url = klempner.url.build_url(


### PR DESCRIPTION
This PR changes the consul agent configuration from a simple IP and port number to a URL so that connections to consul can be secured with HTTPS.

I also reworked cache resetting.  Calling `klempner.config.configure(UNSET)` completely resets the library.  This shouldn't be necessary unless you are testing your code though.  Calls to `klempner.config.configure` already cleared the internal caches when called.  What was missing was the documentation that calling `configure` with `UNSET` is _THE WAY_ to reset things.